### PR TITLE
Add support for alternate encryption schemes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ This method provides the data needed to create a request to add your payment pas
       cardholderName: 'Test User',
       primaryAccountNumberSuffix: '1234',
       localizedDescription: 'Description of payment card',
-      paymentNetwork: 'VISA'
+      paymentNetwork: 'VISA',
+      encryptionScheme: 'RSA_V2'
     }
     AppleWallet.startAddPaymentPass(data)
     .then((res) => {

--- a/src/ios/CDVAppleWallet.m
+++ b/src/ios/CDVAppleWallet.m
@@ -225,7 +225,20 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
         // Options
         NSDictionary* options = [arguments objectAtIndex:0];
         
-        PKAddPaymentPassRequestConfiguration* configuration = [[PKAddPaymentPassRequestConfiguration alloc] initWithEncryptionScheme:PKEncryptionSchemeRSA_V2];
+        // encryption scheme to be used (RSA_V2 or ECC_V2)
+        NSString* scheme = [options objectForKey:@"encryptionScheme"];
+        PKEncryptionScheme encryptionScheme = PKEncryptionSchemeRSA_V2;
+        if (scheme != nil) {
+            if([[scheme uppercaseString] isEqualToString:@"RSA_V2"]) {
+                encryptionScheme = PKEncryptionSchemeRSA_V2;
+            }
+            
+            if([[scheme uppercaseString] isEqualToString:@"ECC_V2"]) {
+                encryptionScheme = PKEncryptionSchemeECC_V2;
+            }
+        }
+
+        PKAddPaymentPassRequestConfiguration* configuration = [[PKAddPaymentPassRequestConfiguration alloc] initWithEncryptionScheme:encryptionScheme];
         
         // The name of the person the card is issued to
         configuration.cardholderName = [options objectForKey:@"cardholderName"];


### PR DESCRIPTION
Fixes #9 
Adds an optional configuration option encryptionScheme to the startAddPaymentPass configuration data with two possible values (RSA_V2, ECC_V2), which correspond to the encryption schemes provided by Apple. If encryptionScheme is not set, it defaults to current default (RSA_V2).