### PR TITLE
Automatically filter already added devices

### DIFF
--- a/src/ios/CDVAppleWallet.m
+++ b/src/ios/CDVAppleWallet.m
@@ -255,7 +255,7 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
         }
     }
     
-    return @"";
+    return nil;
 }
 
 
@@ -302,7 +302,7 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
         configuration.localizedDescription = [options objectForKey:@"localizedDescription"];
         
         // Filters the device and attached devices that already have this card provisioned. No filter is applied if the parameter is omitted
-        configuration.primaryAccountIdentifier = [options objectForKey:@"primaryAccountIdentifier"]; //@"V-3018253329239943005544";//@"";
+        configuration.primaryAccountIdentifier = [self getCardFPAN:configuration.primaryAccountSuffix]; //@"V-3018253329239943005544";//@"";
         
         
         // Filters the networks shown in the introduction view to this single network.


### PR DESCRIPTION
PKAddPaymentPassRequestConfiguration allows filtering out devices,
which already have the card added. This requires
to enumerate cards by suffix, identify their primaryAccountIdentifier
and then supply this identifier to the configuration. If the card was
not found, the parameter needs to be nil.