### PR TITLE
Optional key properties for completeAddPaymentPass

### DIFF
--- a/src/ios/CDVAppleWallet.m
+++ b/src/ios/CDVAppleWallet.m
@@ -414,10 +414,16 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
         NSString* activationData = [options objectForKey:@"activationData"];
         NSString* encryptedPassData = [options objectForKey:@"encryptedPassData"];
         NSString* wrappedKey = [options objectForKey:@"wrappedKey"];
+        NSString* ephemeralPublicKey = [options objectForKey:@"ephemeralPublicKey"];
         
         request.activationData = [[NSData alloc] initWithBase64EncodedString:activationData options:0]; //[activationData dataUsingEncoding:NSUTF8StringEncoding];
         request.encryptedPassData = [[NSData alloc] initWithBase64EncodedString:encryptedPassData options:0];
-        request.wrappedKey = [[NSData alloc] initWithBase64EncodedString:wrappedKey options:0];
+        if (wrappedKey) {
+            request.wrappedKey = [[NSData alloc] initWithBase64EncodedString:wrappedKey options:0];
+        }
+        if (ephemeralPublicKey) {
+            request.ephemeralPublicKey = [[NSData alloc] initWithBase64EncodedString:ephemeralPublicKey options:0];
+        }
         
         // Issue request
         self.completionHandler(request);


### PR DESCRIPTION
RSA and ECC encryption schemes require different properties to be sent
to the completion handler. RSA requires wrappedKey, while ECC requires
ephemeralPublicKey.

Fix for #15 .