### PR TITLE
Changed the object key from primaryAccountSuffix to primaryAccountNum…

### DIFF
--- a/src/ios/CDVAppleWallet.m
+++ b/src/ios/CDVAppleWallet.m
@@ -296,7 +296,7 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
         configuration.cardholderName = [options objectForKey:@"cardholderName"];
         
         // Last 4/5 digits of PAN. The last four or five digits of the PAN. Presented to the user with dots prepended to indicate that it is a suffix.
-        configuration.primaryAccountSuffix = [options objectForKey:@"primaryAccountSuffix"];
+        configuration.primaryAccountSuffix = [options objectForKey:@"primaryAccountNumberSuffix"];
         
         // A short description of the card.
         configuration.localizedDescription = [options objectForKey:@"localizedDescription"];


### PR DESCRIPTION
Everywhere else in this code, and in the CardData interface, the object key used is primaryAccountNumberSuffix. This change is so that those who implement the CardData interface don't have to add a separate property to the class called primaryAccountSuffix. The primaryAccountNumberSuffix will just be used everywhere.