### PR TITLE
Update CDVAppleWallet.m

### DIFF
--- a/src/ios/CDVAppleWallet.m
+++ b/src/ios/CDVAppleWallet.m
@@ -85,7 +85,7 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
                 paymentPasses = [passLibrary remoteSecureElementPasses]; // remotePaymentPasses is deprecated in iOS13.5
                 for (PKSecureElementPass *pass in paymentPasses) {
                     if ([[pass primaryAccountIdentifier] isEqualToString:cardIdentifier]) {
-                        cardAddedtoPasses = true;
+                        cardAddedtoRemotePasses = true;
                     }
                 }
             } else {
@@ -149,7 +149,7 @@ typedef void (^completedPaymentProcessHandler)(PKAddPaymentPassRequest *request)
             paymentPasses = [passLibrary remoteSecureElementPasses];
             for (PKSecureElementPass *pass in paymentPasses) {
               if ([[pass primaryAccountNumberSuffix] isEqualToString:cardSuffix]) {
-                cardAddedtoPasses = true;
+                cardAddedtoRemotePasses = true;
               }
             }
           } else {


### PR DESCRIPTION
While checking eligibility of a card in paired watches having ios greater than or equals to 13.5, wrong boolean value is updated which is resulting card eligibility as true. 